### PR TITLE
Make early termination for unsupported handlers

### DIFF
--- a/mediator.go
+++ b/mediator.go
@@ -28,9 +28,7 @@ func (m Mediator) Subscribe(subscription interface{}) {
 	argKind := typeOf.In(0)
 
 	if typeOf.NumIn() > 1 {
-		// if first argument is context.
-		value := reflect.New(argKind).Interface()
-		if _, ok := value.(context.Context); !ok {
+		if argIsContext(argKind) {
 			argKind = typeOf.In(1)
 		}
 	}
@@ -69,9 +67,7 @@ func (m Mediator) Register(handler interface{}) error {
 	argKind := typeOf.In(0)
 
 	if typeOf.NumIn() > 1 {
-		// if first argument is context.
-		value := reflect.New(argKind).Interface()
-		if _, ok := value.(context.Context); !ok {
+		if argIsContext(argKind) {
 			argKind = typeOf.In(1)
 		}
 	}
@@ -129,4 +125,10 @@ func twoReturnValuesCommand(result []reflect.Value) (interface{}, error) {
 		err = result[1].Interface().(error)
 	}
 	return result[0].Interface(), err
+}
+
+var contextType = reflect.TypeOf(new(context.Context)).Elem()
+
+func argIsContext(typeOf reflect.Type) bool {
+	return contextType == typeOf
 }

--- a/mediator.go
+++ b/mediator.go
@@ -22,7 +22,7 @@ func New() Mediator {
 
 // Subscribe add subscription for domain event.
 // Type of event is detected by arguments of handler.
-func (m Mediator) Subscribe(subscription interface{}) {
+func (m Mediator) Subscribe(subscription interface{}) error {
 	valueOf := reflect.ValueOf(subscription)
 	typeOf := reflect.TypeOf(subscription)
 	argKind := typeOf.In(0)
@@ -30,10 +30,17 @@ func (m Mediator) Subscribe(subscription interface{}) {
 	if typeOf.NumIn() > 1 {
 		if argIsContext(argKind) {
 			argKind = typeOf.In(1)
+		} else {
+			const format = "unsupported event handler %T, event handlers" +
+				" with more than 2 parameters and no context.Context are not" +
+				" supported"
+			return fmt.Errorf(format, subscription)
 		}
 	}
 
 	m.subscriptions[argKind] = append(m.subscriptions[argKind], valueOf)
+
+	return nil
 }
 
 // Publish publishes specified domain event to subscribers.
@@ -65,10 +72,14 @@ func (m Mediator) Publish(ctx context.Context, event interface{}) error {
 func (m Mediator) Register(handler interface{}) error {
 	typeOf := reflect.TypeOf(handler)
 	argKind := typeOf.In(0)
-
 	if typeOf.NumIn() > 1 {
 		if argIsContext(argKind) {
 			argKind = typeOf.In(1)
+		} else {
+			const format = "unsupported command handler %T, command handlers" +
+				" with more than 2 parameters and no context.Context are not" +
+				" supported"
+			return fmt.Errorf(format, handler)
 		}
 	}
 

--- a/mediator_test.go
+++ b/mediator_test.go
@@ -3,6 +3,7 @@ package mediatr
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -248,6 +249,20 @@ func TestReflectMediator_Commands(t *testing.T) {
 		_, _ = mediator.Send(context.Background(), EmbeddedContextEvent{})
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
+		}
+	})
+}
+
+func Test_argIsContext(t *testing.T) {
+	t.Run("Input is a context", func(t *testing.T) {
+		if !argIsContext(reflect.TypeOf(new(context.Context)).Elem()) {
+			t.Fatal("a positive result was expected")
+		}
+	})
+
+	t.Run("Input is not a context", func(t *testing.T) {
+		if argIsContext(reflect.TypeOf(new(EmbeddedContextEvent)).Elem()) {
+			t.Fatal("a negative result was expected")
 		}
 	})
 }

--- a/mediator_test.go
+++ b/mediator_test.go
@@ -18,11 +18,13 @@ func TestReflectMediator_Events(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		mediator.Subscribe(func(event FooEvent) {
+		err := mediator.Subscribe(func(event FooEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_ = mediator.Publish(context.Background(), FooEvent{})
+		err = mediator.Publish(context.Background(), FooEvent{})
+		assertNoError(t, err)
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
 		}
@@ -32,11 +34,12 @@ func TestReflectMediator_Events(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		mediator.Subscribe(func(event BarEvent) {
+		err := mediator.Subscribe(func(event BarEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_ = mediator.Publish(context.Background(), FooEvent{})
+		err = mediator.Publish(context.Background(), FooEvent{})
 		if triggered {
 			t.Fatal("Subscribes was triggered on incorrect event")
 		}
@@ -46,11 +49,12 @@ func TestReflectMediator_Events(t *testing.T) {
 		mediator := New()
 
 		wantErr := errors.New("bus is busy")
-		mediator.Subscribe(func(event BarEvent) error {
+		err := mediator.Subscribe(func(event BarEvent) error {
 			return wantErr
 		})
+		assertNoError(t, err)
 
-		err := mediator.Publish(context.Background(), BarEvent{})
+		err = mediator.Publish(context.Background(), BarEvent{})
 		if err != wantErr {
 			t.Fatal("Publish doesn't return proper error from handler")
 		}
@@ -60,14 +64,16 @@ func TestReflectMediator_Events(t *testing.T) {
 		mediator := New()
 
 		wantErr := errors.New("connection refused")
-		mediator.Subscribe(func(event BarEvent) error {
+		err := mediator.Subscribe(func(event BarEvent) error {
 			return nil
 		})
-		mediator.Subscribe(func(event BarEvent) error {
+		assertNoError(t, err)
+		err = mediator.Subscribe(func(event BarEvent) error {
 			return wantErr
 		})
+		assertNoError(t, err)
 
-		err := mediator.Publish(context.Background(), BarEvent{})
+		err = mediator.Publish(context.Background(), BarEvent{})
 		if err != wantErr {
 			t.Fatalf("Publish doesn't return proper error from handler %q != %q", err, wantErr)
 		}
@@ -79,12 +85,14 @@ func TestReflectMediator_Events(t *testing.T) {
 
 		triggered := false
 		mediator := New()
-		mediator.Subscribe(func(ctx context.Context, event BarEvent) error {
+		err := mediator.Subscribe(func(ctx context.Context, event BarEvent) error {
 			triggered = wantCtx == ctx
 			return nil
 		})
+		assertNoError(t, err)
 
-		_ = mediator.Publish(wantCtx, BarEvent{})
+		err = mediator.Publish(wantCtx, BarEvent{})
+		assertNoError(t, err)
 		if !triggered {
 			t.Fatal("Subscriber is not triggered on event")
 		}
@@ -94,14 +102,22 @@ func TestReflectMediator_Events(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		mediator.Subscribe(func(EmbeddedContextEvent) {
+		err := mediator.Subscribe(func(EmbeddedContextEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_ = mediator.Publish(context.Background(), EmbeddedContextEvent{})
+		err = mediator.Publish(context.Background(), EmbeddedContextEvent{})
+		assertNoError(t, err)
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
 		}
+	})
+
+	t.Run("Registration is not a supported event handler", func(t *testing.T) {
+		mediator := New()
+		err := mediator.Subscribe(func(FooEvent, BarEvent, EmbeddedContextEvent) {})
+		assertError(t, err)
 	})
 }
 
@@ -110,11 +126,12 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		_ = mediator.Register(func(command FooEvent) {
+		err := mediator.Register(func(command FooEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_, _ = mediator.Send(context.Background(), FooEvent{})
+		_, err = mediator.Send(context.Background(), FooEvent{})
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
 		}
@@ -124,11 +141,12 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		_ = mediator.Register(func(command EmbeddedContextEvent) {
+		err := mediator.Register(func(command EmbeddedContextEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_, _ = mediator.Send(context.Background(), EmbeddedContextEvent{})
+		_, err = mediator.Send(context.Background(), EmbeddedContextEvent{})
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
 		}
@@ -138,11 +156,12 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 		wantErr := errors.New("db error")
 
-		_ = mediator.Register(func(command FooEvent) error {
+		err := mediator.Register(func(command FooEvent) error {
 			return wantErr
 		})
+		assertNoError(t, err)
 
-		_, err := mediator.Send(context.Background(), FooEvent{})
+		_, err = mediator.Send(context.Background(), FooEvent{})
 		if err != wantErr {
 			t.Fatal("Send was not receive proper error from handler")
 		}
@@ -152,9 +171,10 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		wantResult := "command result"
-		_ = mediator.Register(func(command FooEvent) string {
+		err := mediator.Register(func(command FooEvent) string {
 			return wantResult
 		})
+		assertNoError(t, err)
 
 		result, _ := mediator.Send(context.Background(), FooEvent{})
 		if result != wantResult {
@@ -166,9 +186,10 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		wantResult := "result"
-		_ = mediator.Register(func(command FooEvent) (string, error) {
+		err := mediator.Register(func(command FooEvent) (string, error) {
 			return wantResult, nil
 		})
+		assertNoError(t, err)
 
 		result, _ := mediator.Send(context.Background(), FooEvent{})
 		if result != wantResult {
@@ -180,11 +201,12 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		wantErr := errors.New("two value returns value error")
-		_ = mediator.Register(func(command FooEvent) (string, error) {
+		err := mediator.Register(func(command FooEvent) (string, error) {
 			return "", wantErr
 		})
+		assertNoError(t, err)
 
-		_, err := mediator.Send(context.Background(), FooEvent{})
+		_, err = mediator.Send(context.Background(), FooEvent{})
 		if err != wantErr {
 			t.Fatal("Send was not receive proper error from handler")
 		}
@@ -194,11 +216,12 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		_ = mediator.Register(func(event BarEvent) {
+		err := mediator.Register(func(event BarEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_, _ = mediator.Send(context.Background(), FooEvent{})
+		_, err = mediator.Send(context.Background(), FooEvent{})
 		if triggered {
 			t.Fatal("Handler was triggered on incorrect command")
 		}
@@ -215,8 +238,9 @@ func TestReflectMediator_Commands(t *testing.T) {
 	t.Run("Second register is forbidden", func(t *testing.T) {
 		mediator := New()
 		commandHandler := func(event BarEvent) {}
-		_ = mediator.Register(commandHandler)
 		err := mediator.Register(commandHandler)
+		assertNoError(t, err)
+		err = mediator.Register(commandHandler)
 		if err == nil {
 			t.Fatal("Command should only have one handler")
 		}
@@ -228,11 +252,12 @@ func TestReflectMediator_Commands(t *testing.T) {
 
 		triggered := false
 		mediator := New()
-		_ = mediator.Register(func(ctx context.Context, command FooEvent) {
+		err := mediator.Register(func(ctx context.Context, command FooEvent) {
 			triggered = wantCtx == ctx
 		})
+		assertNoError(t, err)
 
-		_, _ = mediator.Send(wantCtx, FooEvent{})
+		_, err = mediator.Send(wantCtx, FooEvent{})
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
 		}
@@ -242,14 +267,21 @@ func TestReflectMediator_Commands(t *testing.T) {
 		mediator := New()
 
 		triggered := false
-		_ = mediator.Register(func(EmbeddedContextEvent) {
+		err := mediator.Register(func(EmbeddedContextEvent) {
 			triggered = true
 		})
+		assertNoError(t, err)
 
-		_, _ = mediator.Send(context.Background(), EmbeddedContextEvent{})
+		_, err = mediator.Send(context.Background(), EmbeddedContextEvent{})
 		if !triggered {
 			t.Fatal("Subscribes is not triggered on event")
 		}
+	})
+
+	t.Run("Registration is not a supported command handler", func(t *testing.T) {
+		mediator := New()
+		err := mediator.Register(func(FooEvent, BarEvent, EmbeddedContextEvent) {})
+		assertError(t, err)
 	})
 }
 
@@ -265,4 +297,18 @@ func Test_argIsContext(t *testing.T) {
 			t.Fatal("a negative result was expected")
 		}
 	})
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("received unexpected error: %s", err)
+	}
+}
+
+func assertError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("an error is expected but got nil")
+	}
 }


### PR DESCRIPTION
This is necessary in order to report the use of unsupported handlers as
early as possible, since in the practical case this can cause panic
during processing.